### PR TITLE
Implement Guard Mode & Simulate Pressure Sensor

### DIFF
--- a/backend/src/api/routes/alarm_session.py
+++ b/backend/src/api/routes/alarm_session.py
@@ -1,14 +1,23 @@
+import logging
 from fastapi import APIRouter
 from fastapi import WebSocket, WebSocketDisconnect
 from typing import Optional
 from api.websocket_manager import manager
 from domain.alarms import service as alarm_service
-from domain.alarms.schemas import AlarmSession, AlarmSessionStatus, AlarmSessionWsMessage, AlarmSessionWsType
+from domain.alarms.schemas import AlarmSession, AlarmSessionStatus, AlarmSessionWsMessage, AlarmSessionWsType, PressureSensorEvent
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/alarm-session", tags=["Alarm Sessions"])
 
 @router.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
+    """
+    WebSocket endpoint for real-time alarm state updates.
+    
+    Clients connecting to this endpoint will immediately receive the current 
+    alarm session state (INITIAL_STATE) and subsequent updates (UPDATE) 
+    whenever an alarm transitions (e.g., RINGING -> GUARD -> DISMISSED).
+    """
     await manager.connect(websocket)
     try:
         # Send current session on connect
@@ -17,13 +26,14 @@ async def websocket_endpoint(websocket: WebSocket):
             type=AlarmSessionWsType.INITIAL_STATE,
             session=current_session,
         )
-        await websocket.send_json(message.model_dump())
+        await websocket.send_text(message.model_dump_json())
 
         while True:
             await websocket.receive_text()
     except WebSocketDisconnect:
         manager.disconnect(websocket)
-    except Exception:
+    except Exception as e:
+        logger.error(f"Unexpected WebSocket error: {e}", exc_info=True)
         manager.disconnect(websocket)
 
 @router.get("/current", response_model=Optional[AlarmSession])
@@ -39,14 +49,31 @@ def get_current_alarm_session():
 @router.post("/{session_id}/stop", response_model=Optional[AlarmSession])
 def stop_current_alarm_session(session_id: int):
     """
-        Stops the currently active alarm session.
+        Stops the currently active alarm session and activates guard mode.
         
         :param session_id: The ID of the alarm session
         :type session_id: int
         :return: The updated alarm session
         :rtype: Optional[AlarmSession]
     """
-    return alarm_service.stop_ringing_session(session_id, status=AlarmSessionStatus.DISMISSED)
+    return alarm_service.stop_ringing_session(session_id, status=AlarmSessionStatus.GUARD)
+
+@router.post("/{session_id}/pressure", response_model=Optional[AlarmSession])
+def pressure_sensor_event(
+    session_id: int,
+    body: PressureSensorEvent,
+):
+    """
+        Simulate a pressure sensor event while a guard session is active.
+        If the user goes back to bed after tolerance expires, retriggers the alarm.
+
+        :param session_id: The ID of the guard alarm session
+        :type session_id: int
+        :param body: Pressure sensor payload with pressed state
+        :return: The guard session or updated alarm session on retrigger
+        :rtype: Optional[AlarmSession]
+    """
+    return alarm_service.handle_guard_pressure_sensor(session_id, body.is_pressed)
 
 @router.post("/{session_id}/snooze", response_model=Optional[AlarmSession])
 def snooze_current_alarm_session(session_id: int):

--- a/backend/src/api/routes/alarms.py
+++ b/backend/src/api/routes/alarms.py
@@ -105,8 +105,8 @@ async def websocket_record_name(websocket: WebSocket):
     WebSocket endpoint to record an alarm name via audio,
     transcribe it, and stream the status and result back to the frontend.
     """
-    await websocket.accept()
     global is_recording_globally
+    await websocket.accept()
     stt_service = None
     recording_task = None
 
@@ -185,6 +185,16 @@ async def websocket_record_name(websocket: WebSocket):
 
     except WebSocketDisconnect:
         print("Frontend hat die Verbindung getrennt.")
+    except Exception as e:
+        print(f"Backend WebSocket Error: {e}")
+        try:
+            response = TranscriptionResponse(
+                isListening=False,
+                error=f"Server-Fehler: {str(e)}"
+            )
+            await websocket.send_text(response.model_dump_json())
+        except Exception:
+            pass
     finally:
         if stt_service is not None:
             stt_service.stop_recording()

--- a/backend/src/db/alarm_sessions_repo.py
+++ b/backend/src/db/alarm_sessions_repo.py
@@ -12,27 +12,60 @@ def create_alarm_sessions_table():
             status TEXT NOT NULL,
             started_at TEXT NOT NULL,
             snoozed_until TEXT,
+            guard_expires_at TEXT,
+            guard_tolerance_until TEXT,
+            pressure_started_at TEXT,
             label TEXT,
             ring_count INTEGER DEFAULT 0,
             FOREIGN KEY (alarm_id) REFERENCES alarms (id)
         )
         """
     )
+    _ensure_alarm_sessions_columns()
+
+
+def _ensure_alarm_sessions_columns():
+    existing_columns = [
+        column["name"]
+        for column in db.fetch_all("PRAGMA table_info(alarm_sessions)")
+    ]
+
+    if "guard_expires_at" not in existing_columns:
+        db.execute("ALTER TABLE alarm_sessions ADD COLUMN guard_expires_at TEXT")
+
+    if "guard_tolerance_until" not in existing_columns:
+        db.execute("ALTER TABLE alarm_sessions ADD COLUMN guard_tolerance_until TEXT")
+
+    if "pressure_started_at" not in existing_columns:
+        db.execute("ALTER TABLE alarm_sessions ADD COLUMN pressure_started_at TEXT")
 def create_alarm_session(
     alarm_id: int,
     status: AlarmSessionStatus,
     started_at: datetime,
     snoozed_until: datetime=None,
+    guard_expires_at: datetime=None,
+    guard_tolerance_until: datetime=None,
+    pressure_started_at: datetime=None,
     label: str=None,
     ring_count: int=0,
 ):
     session_id: int = db.execute(
         """
         INSERT INTO alarm_sessions (
-            alarm_id, status, started_at, snoozed_until, label, ring_count
-        ) VALUES (?, ?, ?, ?, ?, ?)
+            alarm_id, status, started_at, snoozed_until, guard_expires_at, guard_tolerance_until, pressure_started_at, label, ring_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        (alarm_id, status, started_at, snoozed_until, label, ring_count),
+        (
+            alarm_id,
+            status,
+            started_at,
+            snoozed_until,
+            guard_expires_at,
+            guard_tolerance_until,
+            pressure_started_at,
+            label,
+            ring_count,
+        ),
     )
     return get_alarm_session_by_id(session_id)
 
@@ -47,11 +80,16 @@ def get_unresolved_alarm_session_by_alarm_id(alarm_id: int):
         db.fetch_one(
             """
             SELECT * FROM alarm_sessions
-            WHERE alarm_id = ? AND status IN (?, ?)
+            WHERE alarm_id = ? AND status IN (?, ?, ?)
             ORDER BY started_at DESC, id DESC
             LIMIT 1
             """,
-            (alarm_id, AlarmSessionStatus.RINGING, AlarmSessionStatus.SNOOZED),
+            (
+                alarm_id,
+                AlarmSessionStatus.RINGING,
+                AlarmSessionStatus.SNOOZED,
+                AlarmSessionStatus.GUARD,
+            ),
         )
     )
 
@@ -82,6 +120,19 @@ def get_active_alarm_session():
         )
     )
 
+def get_latest_guard_alarm_session():
+    return serialize_alarm_session_row(
+        db.fetch_one(
+            """
+            SELECT * FROM alarm_sessions
+            WHERE status = ?
+            ORDER BY guard_expires_at DESC, id DESC
+            LIMIT 1
+            """,
+            (AlarmSessionStatus.GUARD,),
+        )
+    )
+
 def get_latest_snoozed_alarm_session():
     return serialize_alarm_session_row(
         db.fetch_one(
@@ -100,9 +151,15 @@ def update_alarm_session(
     session_id: int,
     status: AlarmSessionStatus=None,
     snoozed_until: datetime=None,
+    guard_expires_at: datetime=None,
+    guard_tolerance_until: datetime=None,
+    pressure_started_at: datetime=None,
     label: str=None,
     ring_count: int=None,
     clear_snoozed_until=False,
+    clear_guard_expires_at=False,
+    clear_guard_tolerance_until=False,
+    clear_pressure_started_at=False,
 ):
     fields = []
     params = []
@@ -116,6 +173,27 @@ def update_alarm_session(
         params.append(snoozed_until)
     elif clear_snoozed_until:
         fields.append("snoozed_until = ?")
+        params.append(None)
+
+    if guard_expires_at is not None:
+        fields.append("guard_expires_at = ?")
+        params.append(guard_expires_at)
+    elif clear_guard_expires_at:
+        fields.append("guard_expires_at = ?")
+        params.append(None)
+
+    if guard_tolerance_until is not None:
+        fields.append("guard_tolerance_until = ?")
+        params.append(guard_tolerance_until)
+    elif clear_guard_tolerance_until:
+        fields.append("guard_tolerance_until = ?")
+        params.append(None)
+
+    if pressure_started_at is not None:
+        fields.append("pressure_started_at = ?")
+        params.append(pressure_started_at)
+    elif clear_pressure_started_at:
+        fields.append("pressure_started_at = ?")
         params.append(None)
 
     if label is not None:

--- a/backend/src/domain/alarms/schemas.py
+++ b/backend/src/domain/alarms/schemas.py
@@ -27,6 +27,7 @@ class Alarm(BaseModel):
 class AlarmSessionStatus(str, Enum):
     RINGING = "RINGING"
     SNOOZED = "SNOOZED"
+    GUARD = "GUARD"
     DISMISSED = "DISMISSED"
 
 class AlarmSession(BaseModel):
@@ -35,6 +36,9 @@ class AlarmSession(BaseModel):
     status: AlarmSessionStatus
     started_at: datetime
     snoozed_until: datetime | None = None
+    guard_expires_at: datetime | None = None
+    guard_tolerance_until: datetime | None = None
+    pressure_started_at: datetime | None = None
     label: str | None = None
     ring_count: int = 0
     message: str | None = None
@@ -51,3 +55,6 @@ class AlarmSessionWsType(str, Enum):
 class AlarmSessionWsMessage(BaseModel):
     type: str
     session: Optional[AlarmSession] = None
+    
+class PressureSensorEvent(BaseModel):
+    is_pressed: bool = True

--- a/backend/src/domain/alarms/service.py
+++ b/backend/src/domain/alarms/service.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import os
 from datetime import datetime, timedelta
 from api.websocket_manager import manager
 
@@ -10,6 +11,10 @@ from domain.alarms.schemas import AlarmSession, AlarmSessionStatus, Weekday, Ala
 from domain.alarms.helper.alarm_helper import validate_weekdays
 
 logger = logging.getLogger(__name__)
+
+# Configurable time windows for development (defaults to 30s guard expiry and 60s tolerance)
+GUARD_EXPIRES_SECONDS = int(os.getenv("GUARD_EXPIRES_SECONDS", 30))
+GUARD_TOLERANCE_SECONDS = int(os.getenv("GUARD_TOLERANCE_SECONDS", 10))
 
 WEEKDAY_MAP = {
     0: Weekday.MON,
@@ -81,7 +86,22 @@ def delete_alarm_by_time(time_value):
 
 def get_current_alarm_session():
     """Return the currently active alarm session, if any."""
-    return alarm_sessions_repo.get_active_alarm_session()
+    current_session = alarm_sessions_repo.get_active_alarm_session()
+    if current_session:
+        return current_session
+
+    guard_session = alarm_sessions_repo.get_latest_guard_alarm_session()
+    if not guard_session:
+        return None
+
+    guard_expires_at = guard_session.get("guard_expires_at")
+    if not guard_expires_at:
+        return None
+
+    if datetime.fromisoformat(guard_expires_at) > datetime.now():
+        return guard_session
+
+    return None
 
 
 # MONITORING LOGIC
@@ -159,17 +179,86 @@ def _resume_snoozed_session_if_due(current_datetime):
     _broadcast_alarm_state(updated_session)
     return True
 
+def _retrigger_guard_session_if_due(current_datetime):
+    """
+    Retrigger a guard session if pressure has been held past the tolerance period.
+    This acts as a background check to catch scenarios where pressure is continuously 
+    applied and the initial tolerance timer runs out without a new sensor event.
+    """
+    current_session = alarm_sessions_repo.get_latest_guard_alarm_session()
+    if not current_session:
+        return False
+
+    if current_session["status"] != AlarmSessionStatus.GUARD:
+        return False
+
+    guard_expires_at = current_session.get("guard_expires_at")
+    if guard_expires_at:
+        if current_datetime >= datetime.fromisoformat(guard_expires_at):
+            return False
+
+    pressure_started_at = current_session.get("pressure_started_at")
+    if not pressure_started_at:
+        return False
+
+    pressure_started_at_dt = datetime.fromisoformat(pressure_started_at)
+    if current_datetime - pressure_started_at_dt < timedelta(seconds=GUARD_TOLERANCE_SECONDS):
+        return False
+
+    updated_session = alarm_sessions_repo.update_alarm_session(
+        current_session["id"],
+        status=AlarmSessionStatus.RINGING,
+        clear_guard_expires_at=True,
+        clear_guard_tolerance_until=True,
+        clear_pressure_started_at=True,
+        clear_snoozed_until=True,
+    )
+    alarm_player.start_loop(session_id=current_session["id"])
+    logger.info("Guard alarm session %s retriggered due to sustained pressure", current_session["id"])
+    _broadcast_alarm_state(updated_session)
+    return True
+
+def _dismiss_expired_guard_session_if_due(current_datetime):
+    """
+    Dismiss a guard session if its overall expiration time has passed.
+    Actively transitions the session status to DISMISSED, which triggers 
+    the morning assistant and automatically hides the guard screen on the frontend.
+    """
+    current_session = alarm_sessions_repo.get_latest_guard_alarm_session()
+    if not current_session:
+        return False
+
+    if current_session["status"] != AlarmSessionStatus.GUARD:
+        return False
+
+    guard_expires_at = current_session.get("guard_expires_at")
+    if not guard_expires_at:
+        return False
+
+    if current_datetime >= datetime.fromisoformat(guard_expires_at):
+        stop_ringing_session(current_session["id"], status=AlarmSessionStatus.DISMISSED)
+        logger.info("Guard alarm session %s expired and was dismissed", current_session["id"])
+        return True
+
+    return False
+
 def monitor_alarms(
-    poll_interval=10,
+    poll_interval=1,
     startup_grace_period=60,
 ):
-    """Continuously check for due alarms and call the provided callback."""
+    """
+    Continuously check for due alarms and manage active alarm sessions.
+    The poll_interval is kept low (e.g., 1 second) to ensure immediate responses 
+    when guard tolerance or expiration timers finish.
+    """
     logger.info("Wecker-Monitor gestartet")
     previous_check_datetime = datetime.now() - timedelta(seconds=startup_grace_period)
 
     while True:
         current_datetime = datetime.now()
         _resume_snoozed_session_if_due(current_datetime)
+        _dismiss_expired_guard_session_if_due(current_datetime)
+        _retrigger_guard_session_if_due(current_datetime)
         active_alarms = get_active_alarms()
 
         for alarm in active_alarms:
@@ -198,6 +287,10 @@ def _broadcast_alarm_state(session, message_type=AlarmSessionWsType.UPDATE):
     manager.broadcast_threadsafe(message)
 
 def start_ringing_sesssion(alarm):
+    """
+    Transition an active alarm to the RINGING state and start audio playback.
+    If a session is already ringing or snoozed, it prevents duplicate sessions from being created.
+    """
     existing_session = alarm_sessions_repo.get_unresolved_alarm_session_by_alarm_id(alarm["id"])
     if existing_session and existing_session.get("status") in (
         AlarmSessionStatus.RINGING,
@@ -216,6 +309,14 @@ def start_ringing_sesssion(alarm):
     _broadcast_alarm_state(current_session)
 
 def stop_ringing_session(session_id: int, status=AlarmSessionStatus.DISMISSED):
+    """
+    Stop an active alarm session and transition it to a new state (e.g., SNOOZED, GUARD, or DISMISSED).
+    
+    - Stops the audio player if the session is currently playing.
+    - Sets expiration/tolerance timers based on the target status (e.g., 5 min for SNOOZED, GUARD_EXPIRES_SECONDS for GUARD).
+    - Triggers the Ollama morning assistant (`wake_up`) if the session is fully DISMISSED.
+    - Broadcasts the updated state to connected WebSocket clients.
+    """
     existing_session = alarm_sessions_repo.get_alarm_session_by_id(session_id)
     if not existing_session:
         return None
@@ -231,13 +332,22 @@ def stop_ringing_session(session_id: int, status=AlarmSessionStatus.DISMISSED):
         )
 
     snoozed_until_time = (datetime.now() + timedelta(minutes=5)).isoformat() if status == AlarmSessionStatus.SNOOZED else None
-    if (snoozed_until_time != None):
+    if snoozed_until_time is not None:
         snoozed_until_time = datetime.fromisoformat(str(snoozed_until_time))
+
+    guard_expires_at_time = None
+    if status == AlarmSessionStatus.GUARD:
+        guard_expires_at_time = datetime.now() + timedelta(seconds=GUARD_EXPIRES_SECONDS)
+
     session = alarm_sessions_repo.update_alarm_session(
         session_id,
         status=status,
         snoozed_until=snoozed_until_time,
+        guard_expires_at=guard_expires_at_time,
         clear_snoozed_until=status != AlarmSessionStatus.SNOOZED,
+        clear_guard_expires_at=status != AlarmSessionStatus.GUARD,
+            clear_guard_tolerance_until=True,
+            clear_pressure_started_at=True,
     )
 
     if should_stop_audio:
@@ -246,6 +356,8 @@ def stop_ringing_session(session_id: int, status=AlarmSessionStatus.DISMISSED):
     _broadcast_alarm_state(session)
 
     if status == AlarmSessionStatus.DISMISSED and session:
+        # When the alarm is fully dismissed (either manually or after the guard timer expires),
+        # trigger the morning assistant to provide a briefing.
         alarm = alarms_repo.get_alarm_by_id(session["alarm_id"])
         if alarm:
             from domain.assistant.service import wake_up, is_ollama_available
@@ -271,3 +383,73 @@ def stop_ringing_session(session_id: int, status=AlarmSessionStatus.DISMISSED):
             )
 
     return session
+
+
+def handle_guard_pressure_sensor(session_id: int, pressed: bool = True):
+    """
+    Handle pressure sensor events while a guard session is active.
+    
+    - If the user gets into bed (pressed=True): starts the tolerance timer.
+      If the tolerance timer has already been running and is expired, it retriggers the alarm.
+      
+    - If the user gets out of bed (pressed=False): clears the tolerance timer and pressure start time,
+      resetting the sensor state back to ready.
+    """
+    existing_session = alarm_sessions_repo.get_alarm_session_by_id(session_id)
+    if not existing_session:
+        return None
+
+    if existing_session.get("status") != AlarmSessionStatus.GUARD:
+        return existing_session
+
+    guard_expires_at = existing_session.get("guard_expires_at")
+    if not guard_expires_at:
+        return existing_session
+
+    now = datetime.now()
+    guard_expires_at_dt = datetime.fromisoformat(guard_expires_at)
+    if guard_expires_at_dt <= now:
+        return existing_session
+
+    if not pressed:
+        # User left the bed, clear the ongoing tolerance timers
+        if existing_session.get("pressure_started_at") is not None:
+            updated_session = alarm_sessions_repo.update_alarm_session(
+                session_id,
+                clear_pressure_started_at=True,
+                clear_guard_tolerance_until=True,
+            )
+            _broadcast_alarm_state(updated_session)
+            return updated_session
+        return existing_session
+
+    pressure_started_at = existing_session.get("pressure_started_at")
+    if pressure_started_at:
+        pressure_started_at_dt = datetime.fromisoformat(pressure_started_at)
+    else:
+        # First time pressure is applied, start the tolerance timer
+        pressure_started_at_dt = now
+        guard_tolerance_until_time = now + timedelta(seconds=GUARD_TOLERANCE_SECONDS)
+        updated_session = alarm_sessions_repo.update_alarm_session(
+            session_id,
+            pressure_started_at=pressure_started_at_dt,
+            guard_tolerance_until=guard_tolerance_until_time,
+        )
+        _broadcast_alarm_state(updated_session)
+        return updated_session
+
+    # Pressure has been held, check if tolerance period has passed
+    if now - pressure_started_at_dt < timedelta(seconds=GUARD_TOLERANCE_SECONDS):
+        return existing_session
+    updated_session = alarm_sessions_repo.update_alarm_session(
+        session_id,
+        status=AlarmSessionStatus.RINGING,
+        clear_guard_expires_at=True,
+        clear_guard_tolerance_until=True,
+        clear_pressure_started_at=True,
+        clear_snoozed_until=True,
+    )
+
+    alarm_player.start_loop(session_id=session_id)
+    _broadcast_alarm_state(updated_session)
+    return updated_session

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -776,6 +776,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -3123,6 +3157,37 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/vite/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/vite/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/vite/node_modules/@oxc-project/types": {

--- a/frontend/src/components/AlarmGuardScreen.tsx
+++ b/frontend/src/components/AlarmGuardScreen.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { type AlarmSession } from "../models/alarm-session.model";
+import { toDate } from "../utils/time.util";
+
+type AlarmGuardScreenProps = {
+  session: AlarmSession;
+  onPressureStart: (isPressed: boolean) => Promise<void>;
+};
+
+export function AlarmGuardScreen({
+  session,
+  onPressureStart,
+}: AlarmGuardScreenProps) {
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNow(new Date());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const expiresAt = session.guard_expires_at
+    ? toDate(session.guard_expires_at)
+    : null;
+  const toleranceUntil = session.guard_tolerance_until
+    ? toDate(session.guard_tolerance_until)
+    : null;
+
+  const remainingMillis = expiresAt ? expiresAt.getTime() - now.getTime() : 0;
+  const remainingMinutes = Math.max(0, Math.ceil(remainingMillis / 60000));
+  const totalRemainingSeconds = Math.max(0, Math.ceil(remainingMillis / 1000));
+  const formattedRemaining = `${Math.floor(totalRemainingSeconds / 60)}:${(totalRemainingSeconds % 60).toString().padStart(2, "0")}`;
+
+  const toleranceRemainingMillis = toleranceUntil
+    ? Math.max(0, toleranceUntil.getTime() - now.getTime())
+    : 0;
+  const toleranceActive = toleranceRemainingMillis > 0;
+  const toleranceSeconds = Math.ceil(toleranceRemainingMillis / 1000);
+
+  return (
+    <div className="w-full h-full rounded-[50px] bg-black mix-blend-soft-light">
+      <div className="flex flex-col w-full h-full pt-6.25 pb-6.25 ps-12.5 pe-12.5 rounded-[50px] justify-between">
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-white text-[28px] font-semibold">
+            Guard Mode aktiv
+          </p>
+          <p className="text-white text-[20px] text-center max-w-[25rem]">
+            Der Alarm wurde gestoppt. Für die nächsten {remainingMinutes}{" "}
+            Minuten bleibt der Schutz aktiv.
+          </p>
+          <p className="text-white text-[18px] opacity-70">
+            {session.label ?? "Wecker"}
+          </p>
+        </div>
+
+        <div className="flex-1 flex flex-col items-center justify-center gap-4">
+          <div className="rounded-3xl border border-white/20 bg-white/10 p-6 text-center">
+            <p className="text-white text-[50px] font-semibold">
+              {formattedRemaining}
+            </p>
+            <p className="text-white text-[18px] opacity-70">
+              Zeit verbleibend
+            </p>
+          </div>
+          {toleranceActive ? (
+            <p className="text-white text-[18px] opacity-75">
+              Toleranz aktiv: {toleranceSeconds} Sekunden, bevor der Sensor
+              wieder auslöst.
+            </p>
+          ) : (
+            <p className="text-white text-[18px] opacity-75">
+              Sensor bereit: Bei neuem Betreten des Bettes wird der Alarm erneut
+              ausgelöst.
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4 w-full">
+          <button
+            onClick={() =>
+              onPressureStart(
+                session.pressure_started_at === null ? true : false,
+              )
+            }
+            className="h-20 rounded-full bg-white text-black text-[32px] font-medium transition-opacity duration-300 hover:opacity-80"
+          >
+            {session.pressure_started_at === null
+              ? "Sensor betätigen"
+              : "Sensor loslassen"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/HomeScreen.tsx
+++ b/frontend/src/components/HomeScreen.tsx
@@ -10,12 +10,19 @@ import settingsIcon from "/src/assets/alarm/icon-settingsBtn.svg";
 import { AlarmList } from "./alarm/AlarmList";
 import { useAlarmSession } from "../contexts/alarm-session.context";
 import { AlarmRingingScreen } from "./AlarmRingingScreen";
+import { AlarmGuardScreen } from "./AlarmGuardScreen";
 
 export function HomeScreen() {
   const [isCreate, setIsCreate] = useState(false);
   const [isListView, setIsListView] = useState(false);
-  const { isRinging, currentAlarmSession, stopAlarm, snoozeAlarm } =
-    useAlarmSession();
+  const {
+    isRinging,
+    isGuard,
+    currentAlarmSession,
+    stopAlarm,
+    snoozeAlarm,
+    togglePressureSensor,
+  } = useAlarmSession();
 
   if (isRinging && currentAlarmSession) {
     return (
@@ -28,9 +35,25 @@ export function HomeScreen() {
             onSnooze={() => snoozeAlarm()}
           />
         </div>
-        {/* Agent bleibt rechts */}
         <div className="col-span-3">
           <Agent />
+        </div>
+      </div>
+    );
+  }
+
+  if (isGuard && currentAlarmSession) {
+    return (
+      <div className="w-full h-full overflow-hidden grid grid-cols-5 p-12 gap-6">
+        {/* Guard mode widget */}
+        <div className="col-span-2 h-full">
+          <AlarmGuardScreen
+            session={currentAlarmSession}
+            onPressureStart={togglePressureSensor}
+          />
+        </div>
+        <div className="col-span-3">
+          <Agent isGuard />
         </div>
       </div>
     );

--- a/frontend/src/components/agent/Agent.tsx
+++ b/frontend/src/components/agent/Agent.tsx
@@ -24,7 +24,11 @@ const RAIN_DROP_POSITIONS = [
   "absolute -bottom-9 left-[73%] z-0 w-[20%]",
 ] as const;
 
-export function Agent() {
+type AgentProps = {
+  isGuard?: boolean;
+};
+
+export function Agent({ isGuard = false }: AgentProps) {
   const { data: weatherData, isLoading, error } = useWeatherNowcast();
   const phase = usePhase();
 
@@ -115,7 +119,7 @@ export function Agent() {
             src={phase === PhaseSchema.parse("Night") ? molinoBase : solinoBase}
             alt="Solino Base"
           />
-          {getExpression(false, phase)}
+          {getExpression(isGuard, phase)}
         </div>
       </div>
     </>

--- a/frontend/src/contexts/alarm-session-provider.tsx
+++ b/frontend/src/contexts/alarm-session-provider.tsx
@@ -3,6 +3,7 @@ import { useAlarmSessionWebSocket } from "../hooks/useAlarmSessionWebSocket";
 import { alarmSessionService } from "../services/alarm-session.service";
 import { AlarmSessionContext } from "./alarm-session.context";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AlarmSessionStatusSchema } from "../models/alarm-session.model";
 
 type AlarmSessionProviderProps = {
   client: ReturnType<typeof useQueryClient>;
@@ -42,10 +43,24 @@ export function AlarmSessionProvider({
     },
   });
 
+  const pressureSensorMutation = useMutation({
+    mutationFn: async (isPressed: boolean) => {
+      if (!data) return null;
+      return alarmSessionService.triggerPressureSensor(data.id, isPressed);
+    },
+    onSuccess: (updatedSession) => {
+      setData(updatedSession);
+      void queryClient.invalidateQueries({
+        queryKey: ["alarm-session", "current"],
+      });
+    },
+  });
+
   const value = useMemo(
     () => ({
       currentAlarmSession: data ?? null,
-      isRinging: data?.status === "RINGING",
+      isRinging: data?.status === AlarmSessionStatusSchema.enum.RINGING,
+      isGuard: data?.status === AlarmSessionStatusSchema.enum.GUARD,
       isLoading,
       stopAlarm: async () => {
         await stopMutation.mutateAsync();
@@ -53,8 +68,11 @@ export function AlarmSessionProvider({
       snoozeAlarm: async () => {
         await snoozeMutation.mutateAsync();
       },
+      togglePressureSensor: async (isPressed: boolean) => {
+        await pressureSensorMutation.mutateAsync(isPressed);
+      },
     }),
-    [data, isLoading, stopMutation, snoozeMutation],
+    [data, isLoading, stopMutation, snoozeMutation, pressureSensorMutation],
   );
   return (
     <AlarmSessionContext.Provider value={value}>

--- a/frontend/src/contexts/alarm-session.context.ts
+++ b/frontend/src/contexts/alarm-session.context.ts
@@ -4,8 +4,10 @@ import { type AlarmSession } from "../models/alarm-session.model";
 type AlarmSessionContextValue = {
   currentAlarmSession: AlarmSession | null;
   isRinging: boolean;
+  isGuard: boolean;
   stopAlarm: () => Promise<void>;
   snoozeAlarm: () => Promise<void>;
+  togglePressureSensor: (isPressed: boolean) => Promise<void>;
   isLoading: boolean;
 };
 

--- a/frontend/src/models/alarm-session.model.ts
+++ b/frontend/src/models/alarm-session.model.ts
@@ -4,6 +4,7 @@ export const AlarmSessionStatusSchema = z.enum([
   "RINGING",
   "SNOOZED",
   "DISMISSED",
+  "GUARD",
 ]);
 
 export const AlarmSessionSchema = z.object({
@@ -12,6 +13,9 @@ export const AlarmSessionSchema = z.object({
   status: AlarmSessionStatusSchema,
   started_at: z.string(),
   snoozed_until: z.string().nullable(),
+  guard_expires_at: z.string().nullable(),
+  guard_tolerance_until: z.string().nullable(),
+  pressure_started_at: z.string().nullable(),
   label: z.string().nullable(),
   ring_count: z.number(),
   message: z.string().nullable().optional(),

--- a/frontend/src/services/alarm-name-recorder.ts
+++ b/frontend/src/services/alarm-name-recorder.ts
@@ -1,4 +1,3 @@
-
 export interface TranscriptionResponse {
   transcription: string | null;
   isListening: boolean;
@@ -9,7 +8,6 @@ export type StatusChangeCallback = (isListening: boolean) => void;
 export type ProcessingChangeCallback = (isProcessing: boolean) => void;
 export type ResultCallback = (text: string) => void;
 export type ErrorCallback = (error: string) => void;
-
 
 class AlarmNameRecorder {
   private ws: WebSocket | null = null;
@@ -22,7 +20,7 @@ class AlarmNameRecorder {
     onStatusChange: StatusChangeCallback,
     onProcessingChange: ProcessingChangeCallback,
     onResult: ResultCallback,
-    onError: ErrorCallback
+    onError: ErrorCallback,
   ) {
     this.onStatusChange = onStatusChange;
     this.onProcessingChange = onProcessingChange;
@@ -30,11 +28,32 @@ class AlarmNameRecorder {
     this.onError = onError;
   }
 
-  public connect(): void {
-    this.ws = new WebSocket("ws://localhost:8000/alarms/ws/record-name");
+  public connect(autoStart: boolean = false): void {
+    // Prevent duplicate connections if the user clicks rapidly
+    if (
+      this.ws &&
+      (this.ws.readyState === WebSocket.OPEN ||
+        this.ws.readyState === WebSocket.CONNECTING)
+    ) {
+      return;
+    }
+
+    // Dynamically get the base URL like in api-client.ts
+    let apiBase =
+      import.meta.env.VITE_BACKEND_IP?.trim() || "http://127.0.0.1:8000";
+    apiBase = apiBase.replace("localhost", "127.0.0.1"); // Force IPv4 to prevent resolution errors
+    const normalizedBase = apiBase.endsWith("/")
+      ? apiBase.slice(0, -1)
+      : apiBase;
+    const wsBase = normalizedBase.replace(/^http/, "ws");
+    this.ws = new WebSocket(`${wsBase}/alarms/ws/record-name`);
 
     this.ws.onopen = () => {
       console.log("✨ Verbunden mit Susonnes Audio-Socket");
+      this.onError("");
+      if (autoStart && this.ws) {
+        this.ws.send(JSON.stringify({ action: "start" }));
+      }
     };
 
     this.ws.onmessage = (event: MessageEvent) => {
@@ -64,18 +83,22 @@ class AlarmNameRecorder {
         }
       } catch (err) {
         this.onProcessingChange(false);
+        this.onStatusChange(false);
         this.onError("Fehler beim Verarbeiten der Server-Daten.");
       }
     };
 
     this.ws.onerror = (error: Event) => {
       this.onProcessingChange(false);
+      this.onStatusChange(false);
       this.onError("WebSocket-Verbindungsfehler");
       console.error("WS Error:", error);
     };
 
     this.ws.onclose = () => {
+      this.ws = null;
       this.onProcessingChange(false);
+      this.onStatusChange(false);
       console.log("WebSocket-Verbindung geschlossen.");
     };
   }
@@ -84,10 +107,13 @@ class AlarmNameRecorder {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.onProcessingChange(false);
       this.ws.send(JSON.stringify({ action: "start" }));
+    } else if (this.ws && this.ws.readyState === WebSocket.CONNECTING) {
+      this.onProcessingChange(true);
+      // Connection is already establishing; autoStart will trigger on open
     } else {
-      this.onProcessingChange(false);
-      this.onError("Verbindung zum Server fehlt. Versuche es erneut.");
-      this.connect();
+      // If not connected, indicate processing and auto-start once connected
+      this.onProcessingChange(true);
+      this.connect(true);
     }
   }
 

--- a/frontend/src/services/alarm-session.service.ts
+++ b/frontend/src/services/alarm-session.service.ts
@@ -35,6 +35,22 @@ class AlarmSessionService {
       throw err;
     }
   }
+
+  async triggerPressureSensor(
+    sessionId: number,
+    isPressed: boolean,
+  ): Promise<AlarmSession> {
+    try {
+      return await apiClient.post(`${this.baseUrl}/${sessionId}/pressure`, {
+        is_pressed: isPressed,
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        console.error("alarmSession.triggerPressureSensor error:", err.message);
+      }
+      throw err;
+    }
+  }
 }
 
 export const alarmSessionService = new AlarmSessionService();


### PR DESCRIPTION
Dieser Pull Request implementiert den "Guard Mode". Dieses Feature stellt sicher, dass der Nutzer nach dem Ausschalten des Weckers auch wirklich aufsteht und das Bett verlässt. Legt sich der Nutzer wieder hin, wird der Wecker nach einer kurzen Toleranzzeit erneut ausgelöst.

**Neue Features & Änderungen:**

- **Automatischer Guard Mode:** Nach dem Beenden (Dismiss) eines Weckers schaltet das System automatisch in den Guard Mode. Dieser bleibt für ein festgelegtes Zeitfenster (aktuell 30 Sekunden) aktiv.
- **Drucksensor-Überwachung & Toleranz**: Im Guard Mode wird ein Drucksensor überwacht. Registriert dieser durchgehend Gewicht, startet ein Toleranztimer (aktuell 10 Sekunden).
- **Alarm Re-Trigger:** Läuft der Toleranztimer ab, wird der Wecker sofort neu gestartet. Dies ermöglicht eine Endlosschleife, bis der Nutzer tatsächlich aufsteht.
- **UI-Simulation**: Ein neuer Button "Sensor betätigen" wurde hinzugefügt, um die Funktionalität zu testen. Er fungiert als Toggle und simuliert die Sensorzustände ("Drucksignal erkannt" / "Drucksignal entfernt"). Das Betätigen des Buttons startet direkt den Toleranztimer.

Die Einstellung der Zeiten wird später in #10 konfigurierbar gemacht

Die finale UI muss noch gemacht werden

<img width="950" height="537" alt="image" src="https://github.com/user-attachments/assets/c31e861e-18c2-4a6a-a7b6-20e368d4b9ab" />
<img width="950" height="533" alt="image" src="https://github.com/user-attachments/assets/2eb6ea40-6e36-4b3d-b7dc-f1d8359648be" />
